### PR TITLE
Default AI receipt upload to camera on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-finance-tracker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-finance-tracker",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.958.0",
         "@aws-sdk/s3-request-presigner": "^3.958.0",

--- a/src/components/AIChat.test.tsx
+++ b/src/components/AIChat.test.tsx
@@ -81,6 +81,13 @@ describe('AIChat', () => {
         expect(screen.getByPlaceholderText('Type expenses naturally...')).toBeEnabled();
     });
 
+    it('sets capture environment on receipt file input', () => {
+        (useSettingsStore as any).mockReturnValue({ licenseKey: 'valid-key' });
+        const { container } = render(<AIChat />);
+        const input = container.querySelector('input[type="file"]');
+        expect(input).toHaveAttribute('capture', 'environment');
+    });
+
     it('handles low confidence response correctly', async () => {
         (useSettingsStore as any).mockReturnValue({ licenseKey: 'valid-key' });
         (extractExpenseWithAI as any).mockResolvedValue({

--- a/src/components/AIChat.tsx
+++ b/src/components/AIChat.tsx
@@ -350,6 +350,7 @@ const AIChat: React.FC<AIChatProps> = ({ onSuccess }) => {
                         <input
                             type="file"
                             accept="image/jpeg,image/png,image/jpg"
+                            capture="environment"
                             onChange={handleReceiptUpload}
                             className="hidden"
                             disabled={isUploading}


### PR DESCRIPTION
This change updates the AI receipt upload functionality to automatically open the rear camera when accessed on mobile devices. This is achieved by adding the `capture="environment"` attribute to the file input element. Existing file validation logic remains unchanged. A unit test has been added to verify this attribute is correctly applied.

---
*PR created automatically by Jules for task [17818766418481530752](https://jules.google.com/task/17818766418481530752) started by @syafiqfaiz*